### PR TITLE
Do not assign background-image if no imageURL property present.

### DIFF
--- a/jquery.gamequery.js
+++ b/jquery.gamequery.js
@@ -879,7 +879,9 @@
                 if(animation){
                     gameQuery.animation = animation;
                     gameQuery.currentFrame = 0;
-                    this.css({"background-image": "url("+animation.imageURL+")", "background-position": ""+(-animation.offsetx)+"px "+(-animation.offsety)+"px"});
+
+					if (animation.imageURL !== '') {this.css("backgroundImage", "url('"+animation.imageURL+"')");}
+					this.css({"background-position": ""+(-animation.offsetx)+"px "+(-animation.offsety)+"px"});
 
                     if(gameQuery.animation.type & $.gameQuery.ANIMATION_VERTICAL) {
                         this.css("background-repeat", "repeat-x");


### PR DESCRIPTION
Added minor alterations to code which only assign background-image if imageURL is present. Prevents sprites breaking when no imageURL present and add versatility of assigning background-image via a css class if needed and overriding on a per animation basis.
