### PR TITLE
Optimise IE filter usage

### DIFF
--- a/jquery.gamequery.js
+++ b/jquery.gamequery.js
@@ -1546,12 +1546,15 @@
 				var transform = "translate("+gameQuery.posx+"px, "+gameQuery.posy+"px) rotate("+gameQuery.angle+"deg) scale("+(gameQuery.factor*gameQuery.factorh)+","+(gameQuery.factor*gameQuery.factorv)+")";
 				this.css(cssTransform,transform);
 			} else {
-				var angle_rad = Math.PI * 2 / 360 * gameQuery.angle;
-				// try filter for IE 
-				// For ie from 5.5
-                var cos = Math.cos(angle_rad) * gameQuery.factor;
-                var sin = Math.sin(angle_rad) * gameQuery.factor;
-                this.css("filter","progid:DXImageTransform.Microsoft.Matrix(M11="+(cos*gameQuery.factorh)+",M12="+(-sin*gameQuery.factorv)+",M21="+(sin*gameQuery.factorh)+",M22="+(cos*gameQuery.factorv)+",SizingMethod='auto expand',FilterType='nearest neighbor')");
+                // Only apply filter if really necessary (break PNG alpha channel and is very slow)
+                if (gameQuery.angle !== 0 || gameQuery.factor !== 1 || gameQuery.factorh !== 1 || gameQuery.factorv !== 1) {
+                    var angle_rad = Math.PI * 2 / 360 * gameQuery.angle;
+                    // try filter for IE
+                    // For ie from 5.5
+                    var cos = Math.cos(angle_rad) * gameQuery.factor;
+                    var sin = Math.sin(angle_rad) * gameQuery.factor;
+                    this.css("filter","progid:DXImageTransform.Microsoft.Matrix(M11="+(cos*gameQuery.factorh)+",M12="+(-sin*gameQuery.factorv)+",M21="+(sin*gameQuery.factorh)+",M22="+(cos*gameQuery.factorv)+",SizingMethod='auto expand',FilterType='nearest neighbor')");
+                }
                 var newWidth = this.width();
                 var newHeight = this.height();
                 gameQuery.posOffsetX = (newWidth-gameQuery.width)/2;


### PR DESCRIPTION
Added a check around line 1550 to only apply DXImageTransform.Microsoft.Matrix filter if it is needed (if an element is either rotated or scaled).
This is a relevant improvement for two reasons:
- Improved performance in old IE versions: I went up to 25fps from about 15 fps by getting rid of all the Matrix filters on elements that aren't rotated or scaled.
- PNG alpha channel works in IE8: It seems like IE8 can't handle the Matrix filter and display alpha channels properly (see for example: http://stackoverflow.com/questions/7344829/rotating-a-div-with-png-background-using-the-filtermatrix-method-in-ie-turns-tr. All the proposed solutions there actually do not work). Alpha still breaks of course if you rotate or scale an element, haven't found a solution for that yet.
